### PR TITLE
#8951_-_Problem_with_graphic_template

### DIFF
--- a/assets/css/sass/modules/tiny-slider.scss
+++ b/assets/css/sass/modules/tiny-slider.scss
@@ -168,6 +168,7 @@
 .tns-controls [data-controls] {
 	.woostify-svg-icon {
 		color: currentColor;
+		line-height: normal;
 		svg {
 			width: 18px;
 			height: 18px;

--- a/style.css
+++ b/style.css
@@ -1473,6 +1473,7 @@ a.pswp__share--download:hover {
 
 .tns-controls [data-controls] .woostify-svg-icon {
   color: currentColor;
+  line-height: normal;
 }
 .tns-controls [data-controls] .woostify-svg-icon svg {
   width: 18px;


### PR DESCRIPTION
2 - another error in the template. Single product. Mobile version. Arrows in the "Related Products" module.
The round background must be transparent - Please edit in Customize: https://prnt.sc/qYxpBKA9ugX1 
The arrows must be aligned vertically and horizontally - Fixed